### PR TITLE
Replace all datapin writes with a safe function to avoid bus contention

### DIFF
--- a/SHT1x-ESP.h
+++ b/SHT1x-ESP.h
@@ -82,6 +82,8 @@ class SHT1x
     double getD2ForC(TemperatureMeasurementResolution resolution) const;
     double getD2ForF(TemperatureMeasurementResolution resolution) const;
 
+    void   controlDataPin(uint8_t dataPin, uint8_t val) const;
+    
     const uint8_t _dataPin;
     const uint8_t _clockPin;
 


### PR DESCRIPTION
The code results in bus contention at the end of a readout because the data pin is forced high and the sensor tries to pull it down.

As per the datasheet you should only write the output pin low, or release it to allow the pullup resistor to drive the datapin high.

This pull requests fixes this.

![scope screenshot](https://user-images.githubusercontent.com/697364/143310558-9d81aad4-cb10-49b6-9c04-0d13c8978795.png)


