### PR TITLE
Ensure the library points to the correct git repository

### DIFF
--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
     "repository":
     {
         "type": "git",
-        "url": "https://github.com/Vincent-Pang/SHT1x.git"
+        "url": "https://github.com/beegee-tokyo/SHT1x-ESP"
     },
     "frameworks": "arduino",
 	"platforms": [


### PR DESCRIPTION
When using the reference beegee-tokyo/SHT1x-ESP@^1.0.0 in platformio.ini the tool downloads the wrong version of the library (the one from Vincent-Pang as is referenced in the library.json.

This pull request fixes this.